### PR TITLE
Fulfilment correlation and originating user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/gov/ons/ssdc/common/model/entity/FulfilmentToProcess.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/model/entity/FulfilmentToProcess.java
@@ -21,4 +21,9 @@ public class FulfilmentToProcess {
   @Column private Integer batchQuantity;
 
   @Column private UUID batchId;
+
+  @Column(nullable = false)
+  private UUID correlationId;
+
+  @Column private String originatingUser;
 }

--- a/src/main/java/uk/gov/ons/ssdc/common/model/entity/PrintFileRow.java
+++ b/src/main/java/uk/gov/ons/ssdc/common/model/entity/PrintFileRow.java
@@ -1,14 +1,12 @@
 package uk.gov.ons.ssdc.common.model.entity;
 
-import lombok.Data;
-
+import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import java.util.UUID;
-
+import lombok.Data;
 
 @Data
 @Entity


### PR DESCRIPTION
# Motivation and Context
We should be able to correlate a fulfilment _request_ with the subsequent printing of it, which happens when fulfilments trigger.

# What has changed
Stored the correlation ID and originating user against fulfilments in the table where they are held, waiting until the trigger time arrives.

# How to test?
Run the ATs. Try using the Support Tool to request a paper fulfilment.

# Links
Trello: https://trello.com/c/v3nc5EHo